### PR TITLE
Fix ccache gcc compiler error in CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -39,14 +39,14 @@ jobs:
             ${{ runner.os }}-ccache-${{ matrix.compiler }}-
             ${{ runner.os }}-ccache-
 
-      - name: Set compiler (with ccache)
+      - name: Set compiler
         run: |
           if [ "${{ matrix.compiler }}" = "clang" ]; then
-            echo "CC='ccache clang'" >> $GITHUB_ENV
-            echo "CXX='ccache clang++'" >> $GITHUB_ENV
+            echo "CC=clang" >> $GITHUB_ENV
+            echo "CXX=clang++" >> $GITHUB_ENV
           else
-            echo "CC='ccache gcc'" >> $GITHUB_ENV
-            echo "CXX='ccache g++'" >> $GITHUB_ENV
+            echo "CC=gcc" >> $GITHUB_ENV
+            echo "CXX=g++" >> $GITHUB_ENV
           fi
           ccache --zero-stats || true
 
@@ -55,6 +55,8 @@ jobs:
           cmake -S . -B build \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DBUILD_TESTS=ON \
             -DBUILD_EXAMPLES=ON \
             -DBUILD_TOOLS=ON


### PR DESCRIPTION
Fix CMake compiler detection in CI by using `CMAKE_COMPILER_LAUNCHER` for ccache instead of setting `CC` directly.

The previous configuration `CC='ccache gcc'` caused CMake to fail, as it could not correctly parse the compiler name. This change separates the compiler (`gcc`/`clang`) from the launcher (`ccache`) using CMake's recommended `CMAKE_C_COMPILER_LAUNCHER` and `CMAKE_CXX_COMPILER_LAUNCHER` variables, resolving the build error and maintaining ccache functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-687d22cf-9469-42e7-98bb-21d5090d123a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-687d22cf-9469-42e7-98bb-21d5090d123a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

